### PR TITLE
Add columns to db and change rake:import

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,3 @@
 class Transaction < ActiveRecord::Base
   belongs_to :invoice
-
-  enum result: [ :success, :failed ]
 end

--- a/db/migrate/20160412013944_create_transactions.rb
+++ b/db/migrate/20160412013944_create_transactions.rb
@@ -2,7 +2,8 @@ class CreateTransactions < ActiveRecord::Migration
   def change
     create_table :transactions do |t|
       t.references :invoice, index: true, foreign_key: true
-
+      t.string :result
+      t.string :credit_card_number
       t.timestamps null: false
     end
   end

--- a/db/migrate/20160412014757_add_result_to_transaction.rb
+++ b/db/migrate/20160412014757_add_result_to_transaction.rb
@@ -1,5 +1,0 @@
-class AddResultToTransaction < ActiveRecord::Migration
-  def change
-    add_column :transactions, :result, :integer, null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,9 +65,10 @@ ActiveRecord::Schema.define(version: 20160412025952) do
 
   create_table "transactions", force: :cascade do |t|
     t.integer  "invoice_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer  "result",     null: false
+    t.string   "result"
+    t.string   "credit_card_number"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
   end
 
   add_index "transactions", ["invoice_id"], name: "index_transactions_on_invoice_id", using: :btree

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -32,14 +32,11 @@ namespace :import do
   desc "Import transaction model from csv"
     task transactions: :environment do
       CSV.foreach("data/transactions.csv", headers: true) do |row|
-        if row["result"] == "success"
-          result = 0
-        elsif row["result"] == "failed"
-          result = 1
-        else
-          result = 2
-        end
-        Transaction.create(invoice_id: row["invoice_id"], result: result)
+        Transaction.create(
+          invoice_id: row["invoice_id"],
+          credit_card_number: row["credit_card_number"],
+          result: row["result"]
+        )
     end
   end
 

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :transaction do
-    result Random.rand(0..1)
+    result "success"
     invoice
   end
 end

--- a/spec/requests/api/v1/transactions/find_all_transactions_spec.rb
+++ b/spec/requests/api/v1/transactions/find_all_transactions_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 describe "Transactions API" do
   it "find_all returns multiple transactions" do
     5.times do
-      create(:transaction, result: 0)
+      create(:transaction, result: "success")
     end
     transaction = Transaction.last
 
     3.times do
-      create(:transaction, result: 1)
+      create(:transaction, result: "failed")
     end
 
     expect(Transaction.count).to eq(8)


### PR DESCRIPTION
Some columns were not referred to in the spec, but are used in the spec
harness. This is adjusting for that by adding the columns into the rake task
and models.
